### PR TITLE
Correct spelling

### DIFF
--- a/lib/lonely_coder/mailbox.rb
+++ b/lib/lonely_coder/mailbox.rb
@@ -103,7 +103,7 @@ class OKCupid
       @browser = browser
     end
     
-    def useage
+    def usage
       html = @browser.get('/messages')
       current, max = html.search('p.fullness').text.match(/([\d]+) of ([\d]+)/).captures
       

--- a/lib/lonely_coder/search.rb
+++ b/lib/lonely_coder/search.rb
@@ -50,7 +50,7 @@ class OKCupid
     Search.new(options, @browser)
   end
   
-  # The OKCupid search object. Stores filters and query options and a results set.  Correct useage is to obtain
+  # The OKCupid search object. Stores filters and query options and a results set.  Correct usage is to obtain
   # and instance of this class by using OKCupid#search(options).
   # @see OKCupid#search
   class Search

--- a/spec/mailbox_spec.rb
+++ b/spec/mailbox_spec.rb
@@ -5,7 +5,7 @@ describe "Mailbox" do
     VCR.use_cassette('loading_mailbox', :erb => {username: ENV['OKC_USERNAME'], password: ENV['OKC_PASSWORD']}) do
       okc = OKCupid.new(ENV['OKC_USERNAME'], ENV['OKC_PASSWORD'])
       @mailbox = okc.mailbox
-      @mailbox.useage.should == {
+      @mailbox.usage.should == {
         current: 233,
         max: 300
       }


### PR DESCRIPTION
"useage" --> "usage"

Sorry to be a spelling nazi. I think this could trip some people up in the future.
