### PR TITLE
Use conversation_id rather than conversation_url

### DIFF
--- a/lib/lonely_coder/mailbox.rb
+++ b/lib/lonely_coder/mailbox.rb
@@ -12,20 +12,20 @@ class OKCupid
   class Mailbox
     class MessageSnippet
       
-      attr_accessor :profile_username, :profile_small_avatar_url, :preview, :last_date, :conversation_url
+      attr_accessor :profile_username, :profile_small_avatar_url, :preview, :last_date, :conversation_id
       
       def self.from_html(html)
         profile_username = html.search('a.subject').text
         preview = html.search('.previewline').text
         last_date = html.search('.timestamp').text
-        conversation_url = html.search('p:first').attribute('onclick').text.gsub('window.location=\'', '').gsub('\';','')
+        conversation_id = html.attribute('id').text[/\d+/]
         profile_small_avatar_url = html.search('a.photo img').attribute('src').text
         
         self.new({
           profile_username: profile_username,
           preview: preview,
           last_date: Date.parse(last_date),
-          conversation_url: conversation_url,
+          conversation_id: conversation_id,
           profile_small_avatar_url: profile_small_avatar_url
         })
       end

--- a/spec/mailbox_spec.rb
+++ b/spec/mailbox_spec.rb
@@ -81,8 +81,8 @@ describe "MessageSnippet" do
     @header.preview.should == 'No, I was there like a month ago. I live in EL so  ...'
   end
   
-  it "has a conversation_url" do
-    @header.conversation_url.should == '/messages?readmsg=true&threadid=9950201897626358080&folder=1'
+  it "has a conversation_id" do
+    @header.conversation_id.should == '9950201897626358080'
   end
   
   it "has a last_date" do


### PR DESCRIPTION
This establishes parity with Conversation.by_id which takes an id rather than a URL
